### PR TITLE
Rename ext/main to ext/view and refine exercise content

### DIFF
--- a/application/uimodule/webapp/ext/view/Main.controller.ts
+++ b/application/uimodule/webapp/ext/view/Main.controller.ts
@@ -13,14 +13,14 @@ import { Button$PressEvent } from "sap/m/Button";
 import Supermarket from "../control/Supermarket";
 
 /**
- * @namespace uimodule.ext.main
+ * @namespace uimodule.ext.view
  */
 export default class Main extends Controller {
 
 	/**
 	 * Called when a controller is instantiated and its View controls (if available) are already created.
 	 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
-	 * @memberOf uimodule.ext.main.Main
+	 * @memberOf uimodule.ext.view.Main.controller
 	 */
 	// public onInit(): void {
 	//
@@ -29,7 +29,7 @@ export default class Main extends Controller {
 	/**
 	 * Similar to onAfterRendering, but this hook is invoked before the controller's View is re-rendered
 	 * (NOT before the first rendering! onInit() is used for that one!).
-	 * @memberOf uimodule.ext.main.Main
+	 * @memberOf uimodule.ext.view.Main.controller
 	 */
 	// public  onBeforeRendering(): void {
 	//
@@ -38,7 +38,7 @@ export default class Main extends Controller {
 	/**
 	 * Called when the View has been rendered (so its HTML is part of the document). Post-rendering manipulations of the HTML could be done here.
 	 * This hook is the same one that SAPUI5 controls get after being rendered.
-	 * @memberOf uimodule.ext.main.Main
+	 * @memberOf uimodule.ext.view.Main.controller
 	 */
 	// public  onAfterRendering(): void {
 	//
@@ -46,7 +46,7 @@ export default class Main extends Controller {
 
 	/**
 	 * Called when the Controller is destroyed. Use this one to free resources and finalize activities.
-	 * @memberOf uimodule.ext.main.Main
+	 * @memberOf uimodule.ext.view.Main.controller
 	 */
 	// public onExit(): void {
 	//

--- a/application/uimodule/webapp/ext/view/Main.view.xml
+++ b/application/uimodule/webapp/ext/view/Main.view.xml
@@ -3,7 +3,7 @@
 	xmlns:mvc="sap.ui.core.mvc"
 	xmlns="sap.m"
 	xmlns:cc="uimodule.ext.control"
-	controllerName="uimodule.ext.main.Main">
+	controllerName="uimodule.ext.view.Main.controller">
 	<Page id="Main" showHeader="false" class="sapUiContentPadding">
 		<VBox justifyContent="SpaceBetween" width="100%" height="100%">
 			<VBox alignItems="Center">

--- a/application/uimodule/webapp/manifest.json
+++ b/application/uimodule/webapp/manifest.json
@@ -99,7 +99,7 @@
             "settings": {
               "navigation": {},
               "contextPath": "/Products",
-              "viewName": "uimodule.ext.main.Main"
+              "viewName": "uimodule.ext.view.Main"
             }
           }
         }

--- a/application/uimodule/webapp/test/e2e/sample.test.ts
+++ b/application/uimodule/webapp/test/e2e/sample.test.ts
@@ -13,7 +13,7 @@ describe("samples", () => {
 		const appLocator = {
 			selector: {
 				controlType: "sap.m.Page",
-				viewName: "uimodule.ext.main.Main",
+				viewName: "uimodule.ext.view.Main",
 			},
 		};
 
@@ -25,7 +25,7 @@ describe("samples", () => {
 		const searchLocator = {
 			selector: {
 				id: "searchField",
-				viewName: "uimodule.ext.main.Main",
+				viewName: "uimodule.ext.view.Main",
 			},
 		};
 
@@ -40,7 +40,7 @@ describe("samples", () => {
 		const tilesLocator = {
 			selector: {
 				controlType: "sap.m.GenericTile",
-				viewName: "uimodule.ext.main.Main",
+				viewName: "uimodule.ext.view.Main",
 			},
 		};
 

--- a/application/uimodule/webapp/test/integration/pages/MainPage.ts
+++ b/application/uimodule/webapp/test/integration/pages/MainPage.ts
@@ -5,7 +5,7 @@ import GenericTile from "sap/m/GenericTile";
 import UI5Element from "sap/ui/core/Element";
 
 
-const viewName = "uimodule.ext.main.Main";
+const viewName = "uimodule.ext.view.Main";
 
 export default class MainPage extends Opa5 {
 	// Actions

--- a/application/uimodule/webapp/test/unit/controller/Main.qunit.ts
+++ b/application/uimodule/webapp/test/unit/controller/Main.qunit.ts
@@ -1,4 +1,4 @@
-import Main from "uimodule/ext/main/Main.controller";
+import Main from "uimodule/ext/view/Main.controller";
 
 QUnit.module("Sample Main controller test");
 

--- a/chapters/01-generating-full-stack-project/readme.md
+++ b/chapters/01-generating-full-stack-project/readme.md
@@ -67,7 +67,7 @@ To better understand the generated monorepo project setup, you can inspect the r
 
 <br>
 
-At this point you might be wondering why we enabled the SAP Fiori elements flexible programming model (FPM) for our UI5 application (`uimodule`). The reasons here are (1) that the FPM templates support TypeScript and (2) that the FPM allows us to use all the freestyle development features of UI5 (via custom pages or fragments), while still providing a solid structure and the option of adding Fiori elements features later on, such as [building blocks](https://sapui5.hana.ondemand.com/test-resources/sap/fe/core/fpmExplorer/index.html#/buildingBlocks/buildingBlockOverview) or whole pages (e.g object pages). 
+At this point you might be wondering why we enabled the SAP Fiori elements flexible programming model (FPM) for our UI5 application (`uimodule`). The reasons here are (1) that the FPM templates support TypeScript and (2) that the FPM allows us to use all the freestyle development features of UI5 (via custom pages or fragments), while still providing a solid structure and the option of adding Fiori elements features later on, such as [building blocks](https://ui5.sap.com/test-resources/sap/fe/core/fpmExplorer/index.html#/buildingBlocks/buildingBlockOverview) or whole pages (e.g object pages).
 
 ### 3. Add an SAP CAP server to the project
 

--- a/chapters/03-adding-content-to-ui5-app/readme.md
+++ b/chapters/03-adding-content-to-ui5-app/readme.md
@@ -19,7 +19,7 @@ We want to build an app that allow users to browse and search a list of products
 	xmlns:core="sap.ui.core"
 	xmlns:mvc="sap.ui.core.mvc"
 	xmlns="sap.m"
-	controllerName="uimodule.ext.main.Main">
+	controllerName="uimodule.ext.view.Main">
 	<Page id="Main" showHeader="false" class="sapUiContentPadding">
 		<VBox justifyContent="SpaceBetween" width="100%" height="100%">
 			<VBox alignItems="Center">
@@ -59,25 +59,32 @@ We want to build an app that allow users to browse and search a list of products
 
 We added basic UI5 controls to the main view custom page. As we call these exercises "advanced", nothing here should really surprise you.
 
+> If you have the [UI5 Language Assistant](https://marketplace.visualstudio.com/items?itemName=SAPOSS.vscode-ui5-language-assistant) installed, you will notice that some of the controls above are flagged with errors. The UI5 Language Assistant is a VS Code extension that provides code completion, validation, and quick navigation for UI5 XML views and fragments - it's highly recommended for a smoother XML view editing experience.
+>
+> The errors you see are related to the `flexEnabled` property in the `manifest.json`. When `flexEnabled` is set to `true` (as it is in our generated project), SAPUI5 flexibility (adaptation/personalization) is enabled, and every control that could be adapted needs a stable ID so that changes can be reliably attached to it. Controls without an explicit `id` therefore get flagged. You have two options to resolve this:
+>
+> - Set `"flexEnabled": false` in the `sap.ui5` section of the `manifest.json` if you don't need flexibility features, or
+> - Add an `id` attribute to each of the flagged controls (which is good practice anyway).
+
 ### 2. Add TypeScript controller code for the search feature
 
-➡️ Add the following method to the `codejam.supermarket/uimodule/webapp/ext/main/Main.controller.ts` file:
+➡️ Add the following method to the `codejam.supermarket/uimodule/webapp/ext/view/Main.controller.ts` file:
 
 ```typescript
 	public onSearchProducts(event: SearchField$LiveChangeEvent): void {
-		const filter = []
-		const query = event.getParameter("newValue")
+		const filter = [];
+		const query = event.getParameter("newValue");
 		if (query) {
 			filter.push(new Filter({
 				path: "title",
 				operator: FilterOperator.Contains,
 				value1: query,
 				caseSensitive: false
-			}))
+			}));
 		}
-		const list = this.getView()?.byId("products") as HBox
-		const binding = list.getBinding("items") as ODataListBinding
-		binding.filter(filter)
+		const list = this.getView()?.byId("products") as HBox;
+		const binding = list.getBinding("items") as ODataListBinding;
+		binding.filter(filter);
 	}
 ```
 

--- a/chapters/04-adding-odata-v4-actions-and-debugging/readme.md
+++ b/chapters/04-adding-odata-v4-actions-and-debugging/readme.md
@@ -47,7 +47,7 @@ The rating indicator calls the `onCreateRating()` method on the change event, wh
 
 The OData action and its parameters are now bound to the rating indicator, but still needs to be manually invoked via the controller.
 
-➡️ Add the following method to the `codejam.supermarket/uimodule/webapp/ext/main/Main.controller.ts` file:
+➡️ Add the following method to the `codejam.supermarket/uimodule/webapp/ext/view/Main.controller.ts` file:
 
 ```typescript
 	public onCreateRating(event: RatingIndicator$ChangeEvent) {
@@ -80,7 +80,7 @@ This `onCreateRating()` method is called on the change event of the rating indic
 
 Speaking of issues, debugging is an important part of any development process. Maybe you have noticed that the creating a new rating makes the product images disappear for a fraction of a second. This is caused by calling the `refresh()` method on the whole model, including the images.
 
-➡️ Your task is now to debug this issue and find an alternative way of refreshing the average rating (`/getAvgRating()` binding of the `avgRating` label) without refreshing the whole model. Open the developer tools of your browser, open the "Sources" tab, and set a break point in the `uimodule/ext/main/Main.controller.ts` file after the promise gets resolved. Now submit a new rating and notice how the execution stops at the break point. Inspect the application at that point in time.
+➡️ Your task is now to debug this issue and find an alternative way of refreshing the average rating (`/getAvgRating()` binding of the `avgRating` label) without refreshing the whole model. Open the developer tools of your browser, open the "Sources" tab, and set a break point in the `uimodule/ext/view/Main.controller.ts` file after the promise gets resolved. Now submit a new rating and notice how the execution stops at the break point. Inspect the application at that point in time.
 
 ![breakpoint](./breakpoint.png)
 
@@ -129,15 +129,22 @@ The application now includes a rating indicator. Feel free to test it and see th
 >       operation.invoke().then(() => {
 >           console.log("logging the result...", operation.getBoundContext().getObject());
 >           MessageToast.show("Rating submitted.");
->           const label = this.getView()?.byId("avgRating") as Label
->           const compositeBindings = label.getBinding("text") as CompositeBinding
->           compositeBindings.getBindings()[0].refresh()
+>           const label = this.getView()?.byId("avgRating") as Label;
+>           const compositeBindings = label.getBinding("text") as CompositeBinding;
+>           (compositeBindings.getBindings()[0] as ODataPropertyBinding).refresh();
 >           ratingIndicator.setEnabled(false);
 >       }).catch((error: Error) => {
 >           MessageToast.show(error.message);
 >       });
 >   }
 >```
+>
+> ➡️ Also make sure to add the following imports to the top of the same file:
+> ```typescript
+> import Label from "sap/m/Label";
+> import CompositeBinding from "sap/ui/model/CompositeBinding";
+> import ODataPropertyBinding from "sap/ui/model/odata/v4/ODataPropertyBinding";
+> ```
 
 </details>
 

--- a/chapters/05-custom-controls-and-third-party-packages/readme.md
+++ b/chapters/05-custom-controls-and-third-party-packages/readme.md
@@ -18,14 +18,14 @@ By the end of this chapter we will have built a custom control that uses a third
 - [12. Use custom control methods in controller](#12-use-custom-control-methods-in-controller)<br>
 - [13. Test the custom control](#13-test-the-custom-control)<br>
 
-### 1. Move 3D model into the application
+### 1. Copy 3D model into the application
 
 Before the start with custom control development, let's provide the supermarket 3D model to the application.
 
-➡️ Move the `application/uimodule/webapp/supermarket.glb` file (from the sample application included in this repo) into the `codejam.supermarket/uimodule/webapp` directory. You can do this via your file explorer or use this command:
+➡️ Copy the `application/uimodule/webapp/supermarket.glb` file (from the sample application included in this repo) into the `codejam.supermarket/uimodule/webapp` directory. You can do this via your file explorer or use this command:
 
 ```bash
-mv ../application/uimodule/webapp/supermarket.glb uimodule/webapp/
+cp ../application/uimodule/webapp/supermarket.glb uimodule/webapp/
 ```
 
 ### 2. Install required dependencies
@@ -46,14 +46,14 @@ We also installed the (non-development) dependencies [`three`](https://www.npmjs
 
 ### 3. Add configuration to `ui5.yaml`
 
-➡️ Add the following code to the `codejam.supermarket/uimodule/ui5.yaml` file inside the `customMiddleware` section:
+➡️ Add the following code to the `codejam.supermarket/uimodule/ui5.yaml` file inside the `customMiddleware` section (if not already added by the npm install script with the `-rte` option above):
 
 ```yaml
     - name: ui5-tooling-modules-middleware
       afterMiddleware: compression
 ```
 
-➡️ Add the following code to the `codejam.supermarket/uimodule/ui5.yaml` file inside the `customTasks` section:
+➡️ Add the following code to the `codejam.supermarket/uimodule/ui5.yaml` file inside the `customTasks` section (if not already added by the npm install script with the `-rte` option above):
 
 ```yaml
     - name: ui5-tooling-modules-task
@@ -69,21 +69,21 @@ We can now get into the actual control development. Our custom control will esse
 ➡️ Create a new file `codejam.supermarket/uimodule/webapp/ext/control/Supermarket.ts` with the following content:
 
 ```typescript
-import Control from "sap/ui/core/Control"
-import RenderManager from "sap/ui/core/RenderManager"
-import { MetadataOptions } from "sap/ui/core/Element"
+import Control from "sap/ui/core/Control";
+import RenderManager from "sap/ui/core/RenderManager";
+import { MetadataOptions } from "sap/ui/core/Element";
 import {
 	Scene,
 	PerspectiveCamera,
 	WebGLRenderer,
 	AmbientLight
-} from "three"
-import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader"
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
-import gsap from "gsap"
-import BusyIndicator from "sap/m/BusyIndicator"
-import Button from "sap/m/Button"
-import FlexBox from "sap/m/FlexBox"
+} from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+import gsap from "gsap";
+import BusyIndicator from "sap/m/BusyIndicator";
+import Button from "sap/m/Button";
+import FlexBox from "sap/m/FlexBox";
 
 /**
  * @namespace uimodule.ext.control
@@ -93,7 +93,7 @@ export default class Supermarket extends Control {
 	static readonly metadata: MetadataOptions = {
 		properties: {},
 		aggregations: {}
-	}
+	};
 
     // placeholder for some private variables
 
@@ -110,7 +110,7 @@ export default class Supermarket extends Control {
 	static renderer = {
 		apiVersion: 4,
 		render: (rm: RenderManager, control: Supermarket) => {}
-	}
+	};
 }
 ```
 
@@ -140,15 +140,15 @@ Feel free to check out the UI5 documentation for [guidelines on how to develop c
 				multiple: false
 			}
 		}
-	}
+	};
 
-	private scene: Scene
-	private camera: PerspectiveCamera
-	private threeRenderer: WebGLRenderer
-	private controls: OrbitControls
-	private animationSpeed = 3000
-	private height: number
-	private width: number
+	private scene: Scene;
+	private camera: PerspectiveCamera;
+	private threeRenderer: WebGLRenderer;
+	private controls: OrbitControls;
+	private animationSpeed = 3000;
+	private height: number;
+	private width: number;
 ```
 
 The above metadata (incl. properties and aggregations) and variables lay the foundation for our custom control.
@@ -167,44 +167,44 @@ The above metadata (incl. properties and aggregations) and variables lay the fou
 	init(): void {
 		this.setAggregation("_busyIndicator", new BusyIndicator({
 			visible: true
-		}))
+		}));
 		this.setAggregation("_expand", new Button({
 			icon: "sap-icon://full-screen",
 			press: this.expand.bind(this, {})
-		}))
+		}));
 	}
 
 	onAfterRendering(): void {
 		const canvas = this.getDomRef() as HTMLCanvasElement;
-		const { width, height } = canvas.getBoundingClientRect()
+		const { width, height } = canvas.getBoundingClientRect();
 
-		this.height = height
-		this.width = width
+		this.height = height;
+		this.width = width;
 
 		this.threeRenderer = new WebGLRenderer({
 			canvas: canvas
-		})
-		this.threeRenderer.setSize(width, height)
+		});
+		this.threeRenderer.setSize(width, height);
 
-		this.scene = new Scene()
-		this.camera = new PerspectiveCamera(75, width / height, 0.1, 1000)
+		this.scene = new Scene();
+		this.camera = new PerspectiveCamera(75, width / height, 0.1, 1000);
 
-		const ambientLight = new AmbientLight(0xffffff)
-		this.scene.add(ambientLight)
+		const ambientLight = new AmbientLight(0xffffff);
+		this.scene.add(ambientLight);
 
-		const loader = new GLTFLoader()
+		const loader = new GLTFLoader();
 		loader.load("supermarket.glb", gltf => {
-			this.scene.add(gltf.scene)
-			this.setCameraPosition([{ x: 18.88, y: 2.44, z: -5.2 }], {})
-			const busyIndicator = this.getAggregation("_busyIndicator") as BusyIndicator
-			busyIndicator.setVisible(false)
-		})
+			this.scene.add(gltf.scene);
+			this.setCameraPosition([{ x: 18.88, y: 2.44, z: -5.2 }], {});
+			const busyIndicator = this.getAggregation("_busyIndicator") as BusyIndicator;
+			busyIndicator.setVisible(false);
+		});
 
-		this.controls = new OrbitControls(this.camera, this.threeRenderer.domElement)
+		this.controls = new OrbitControls(this.camera, this.threeRenderer.domElement);
 
-		this.animate()
+		this.animate();
 
-		this.camera.position.set(this.getX(), this.getY(), this.getZ())
+		this.camera.position.set(this.getX(), this.getY(), this.getZ());
 	}
 ```
 
@@ -223,35 +223,35 @@ In the `onAfterRendering()` method, which gets executed after the control has be
 
 ```typescript
 	private animate(): void {
-		this.threeRenderer.render(this.scene, this.camera)
-		this.controls.update()
-		requestAnimationFrame(this.animate.bind(this))
+		this.threeRenderer.render(this.scene, this.camera);
+		this.controls.update();
+		requestAnimationFrame(this.animate.bind(this));
 	}
 
 	public setCameraPosition(coordinates: Array<object>, { backToStart = false }: { backToStart?: boolean }): void {
 		if (backToStart) {
-			this.camera.position.set(18.88, 2.44, -5.2)
+			this.camera.position.set(18.88, 2.44, -5.2);
 		}
-		gsap.to(this.camera.position, { ...coordinates[0], duration: this.animationSpeed / 1000 })
+		gsap.to(this.camera.position, { ...coordinates[0], duration: this.animationSpeed / 1000 });
 		for (let i = 1; i < coordinates.length; i++) {
 			// eslint-disable-next-line @sap-ux/fiori-tools/sap-timeout-usage
 			window.setTimeout(() => {
-				gsap.to(this.camera.position, { ...coordinates[i], duration: this.animationSpeed / 1000 })
-			}, this.animationSpeed)
+				gsap.to(this.camera.position, { ...coordinates[i], duration: this.animationSpeed / 1000 });
+			}, this.animationSpeed);
 		}
 	}
 
 	public expand({ stayExpanded = false }: { stayExpanded?: boolean }): void {
-		const expand = this.getAggregation("_expand") as Button
-		const growFactor = this.getGrowFactor()
-		const icon = expand.getIcon()
-		const factor = icon === "sap-icon://full-screen" || stayExpanded ? growFactor : 1
-		const parent = this.getParent() as FlexBox
-		const parentDOMNode = parent.getDomRef() as HTMLDivElement
-		parentDOMNode.style.height = `${this.height * factor}px`
-		parentDOMNode.style.width = `${this.width * factor}px`
-		this.threeRenderer.setSize(this.width * factor, this.height * factor)
-		expand.setIcon(`sap-icon://${factor === growFactor ? "exit-" : ""}full-screen`)
+		const expand = this.getAggregation("_expand") as Button;
+		const growFactor = this.getGrowFactor();
+		const icon = expand.getIcon();
+		const factor = icon === "sap-icon://full-screen" || stayExpanded ? growFactor : 1;
+		const parent = this.getParent() as FlexBox;
+		const parentDOMNode = parent.getDomRef() as HTMLDivElement;
+		parentDOMNode.style.height = `${this.height * factor}px`;
+		parentDOMNode.style.width = `${this.width * factor}px`;
+		this.threeRenderer.setSize(this.width * factor, this.height * factor);
+		expand.setIcon(`sap-icon://${factor === growFactor ? "exit-" : ""}full-screen`);
 	}
 ```
 
@@ -268,32 +268,32 @@ We defined three methods that are specific to our custom control:
 	static renderer = {
 		apiVersion: 4,
 		render: (rm: RenderManager, control: Supermarket) => {
-			rm.openStart("canvas", control)
-			rm.style("height", "100%")
-			rm.style("width", "100%")
-			rm.openEnd()
-			rm.close("canvas")
-			rm.openStart("div")
-			rm.style("position", "absolute")
-			rm.style("top", "0")
-			rm.style("width", "100%")
-			rm.style("height", "100%")
-			rm.style("display", "flex")
-			rm.style("align-items", "center")
-			rm.style("justify-content", "center")
-			rm.style("pointer-events", "none")
-			rm.openEnd()
-			rm.renderControl(control.getAggregation("_busyIndicator") as Control)
-			rm.close("div")
-			rm.openStart("div")
-			rm.style("position", "absolute")
-			rm.style("top", "0.5rem")
-			rm.style("left", "0.5rem")
-			rm.openEnd()
-			rm.renderControl(control.getAggregation("_expand") as Control)
-			rm.close("div")
+			rm.openStart("canvas", control);
+			rm.style("height", "100%");
+			rm.style("width", "100%");
+			rm.openEnd();
+			rm.close("canvas");
+			rm.openStart("div");
+			rm.style("position", "absolute");
+			rm.style("top", "0");
+			rm.style("width", "100%");
+			rm.style("height", "100%");
+			rm.style("display", "flex");
+			rm.style("align-items", "center");
+			rm.style("justify-content", "center");
+			rm.style("pointer-events", "none");
+			rm.openEnd();
+			rm.renderControl(control.getAggregation("_busyIndicator") as Control);
+			rm.close("div");
+			rm.openStart("div");
+			rm.style("position", "absolute");
+			rm.style("top", "0.5rem");
+			rm.style("left", "0.5rem");
+			rm.openEnd();
+			rm.renderControl(control.getAggregation("_expand") as Control);
+			rm.close("div");
 		}
-	}
+	};
 ```
 
 The renderer is responsible for creating the HTML elements that make up our custom control. We defined the HTML elements and their styles using TypeScript. We also use the `rm.renderControl()` method to render the aggregations (like children UI5 controls inside our custom control) that we defined earlier.
@@ -351,7 +351,7 @@ This `.fixed` CSS class is used on the `FlexBox` that wraps around our custom co
 
 ### 12. Use custom control methods in controller
 
-➡️ Add the following method to the `codejam.supermarket/uimodule/webapp/ext/main/Main.controller.ts` file:
+➡️ Add the following method to the `codejam.supermarket/uimodule/webapp/ext/view/Main.controller.ts` file:
 
 ```typescript
 	public onFlyToProduct(event: Button$PressEvent): void {

--- a/chapters/07-testing-recreating-setup/readme.md
+++ b/chapters/07-testing-recreating-setup/readme.md
@@ -21,7 +21,7 @@ By the end of this chapter, we will know how to recreate and execute a holistic 
 
 ### 1. Add `testsuite.qunit.html` (test suite)
 
-In case we need a bit more control over the generated files, we can also create the boilerplate files manually. This allows us to specify the *QUnit* or *Sinon* version in the test suite as well as to maintain a list of tests to be executed. The tests are triggered by the [UI5 test starter](https://sdk.openui5.org/topic/032be2cb2e1d4115af20862673bedcdb). The concept of UI5 test suite is explained here in the UI5 documentation: <https://sdk.openui5.org/#/topic/22f50c0f0b104bf3ba84620880793d3f>
+In case we need a bit more control over the generated files, we can also create the boilerplate files manually. This allows us to specify the *QUnit* or *Sinon* version in the test suite as well as to maintain a list of tests to be executed. The tests are triggered by the [UI5 test starter](https://ui5.sap.com/topic/032be2cb2e1d4115af20862673bedcdb). The concept of UI5 test suite is explained here in the UI5 documentation: <https://ui5.sap.com/#/topic/22f50c0f0b104bf3ba84620880793d3f>
 
 In this and the subsequent steps we will create the following file structure, which is essentially the boilerplate required to run *QUnit* and *OPA* tests - the so-called *test suite*:
 
@@ -145,7 +145,7 @@ The `Main.qunit.ts` file now defines *QUnit* modules and tests. A very basic che
 ➡️ Create a new file `codejam.supermarket/uimodule/webapp/test/unit/controller/Main.qunit.ts` with the following content:
 
 ```ts
-import Main from "uimodule/ext/main/Main.controller";
+import Main from "uimodule/ext/view/Main.controller";
 
 QUnit.module("Sample Main controller test");
 
@@ -179,8 +179,8 @@ npm start
 
 ➡️ Open the test suite at [http://localhost:8080/test/testsuite.qunit.html]() to run the *QUnit* tests. You can run all tests at once by pressing **Run All** or click on the individual *QUnit* tests to execute.
 
-![Qunit runn all](qunit-run-all.png)
-![Qunit test results](qunit-results.png)
+![QUnit run all](qunit-run-all.png)
+![QUnit test results](qunit-results.png)
 
 ### 8. Add `opaTests.qunit.ts` (list of OPA journeys)
 
@@ -256,7 +256,7 @@ import GenericTile from "sap/m/GenericTile";
 import UI5Element from "sap/ui/core/Element";
 
 
-const viewName = "uimodule.ext.main.Main";
+const viewName = "uimodule.ext.view.Main";
 
 export default class MainPage extends Opa5 {
 	// Actions
@@ -317,7 +317,7 @@ We can now run our *OPA* (integration) tests (together with the unit tests from 
 npm run dev:server
 ```
 
-➡️ Open the test suite at [http://localhost:4004/uimodule/webapp/test/testsuite.qunit.html]() to run the *OPA* (integration) and unit tests. You can run all tests at once by pressing **Run All** or click on the individual tests to execute.
+➡️ Open the test suite at [http://localhost:4004/uimodule/test/testsuite.qunit.html]() to run the *OPA* (integration) and unit tests. You can run all tests at once by pressing **Run All** or click on the individual tests to execute.
 
 ![cds server](cds-server.png)
 ![Qunit runn all](qunit-run-all2.png)
@@ -358,7 +358,7 @@ describe("samples", () => {
 		const appLocator = {
 			selector: {
 				controlType: "sap.m.Page",
-				viewName: "uimodule.ext.main.Main",
+				viewName: "uimodule.ext.view.Main",
 			},
 		};
 
@@ -370,7 +370,7 @@ describe("samples", () => {
 		const searchLocator = {
 			selector: {
 				id: "searchField",
-				viewName: "uimodule.ext.main.Main",
+				viewName: "uimodule.ext.view.Main",
 			},
 		};
 
@@ -385,7 +385,7 @@ describe("samples", () => {
 		const tilesLocator = {
 			selector: {
 				controlType: "sap.m.GenericTile",
-				viewName: "uimodule.ext.main.Main",
+				viewName: "uimodule.ext.view.Main",
 			},
 		};
 
@@ -412,8 +412,10 @@ npm run dev:server
 
 ```sh
 # make sure you are in the uimodule/ directory
-npm run wdi5
+npm run wdi5 -- --baseUrl http://localhost:4004/uimodule/index.html
 ```
+
+We overwrite the baseUrl from the `codejam.supermarket/uimodule/webapp/test/e2e/wdio.conf.ts` which uses the standard port and path from the UI5 dev server to the port and path of the CAP server which we started above.
 
 You will notice how the *WDI5* tests are executed in the browser, similar to the *OPA* tests. The test results are displayed in the terminal.
 


### PR DESCRIPTION
## Summary

Restructures the FPM custom page folder and refines the exercise content for clarity and correctness.

- **Rename `ext/main` → `ext/view`** across the finished `application/` (controller, view, `manifest.json` routing) and all tests (OPA page object, wdi5, QUnit), plus every chapter reference.
- **Chapter 03:** Add a note about the [UI5 Language Assistant](https://marketplace.visualstudio.com/items?itemName=SAPOSS.vscode-ui5-language-assistant) VS Code extension and the `flexEnabled`-related warnings it surfaces, with two ways to resolve them (set `flexEnabled: false`, or add stable `id`s).
- **Chapter 04:** Refine the debugging solution with proper `ODataPropertyBinding` typing and the required import statements.
- **Chapter 05:** Use `cp` instead of `mv` for the 3D model so the sample app stays intact.
- Assorted code-style (semicolons) and URL cleanups.

## Test plan

- [ ] Exercises still resolve to the correct file paths (`ext/view/...`)
- [ ] Finished `application/` runs with the renamed folder
- [ ] Unit / OPA / wdi5 tests pass against the new `viewName`